### PR TITLE
support nodemcu

### DIFF
--- a/src/Sodaq_SHT2x.cpp
+++ b/src/Sodaq_SHT2x.cpp
@@ -114,8 +114,8 @@ uint16_t SHT2xClass::readSensor(uint8_t command)
 
     Wire.beginTransmission(eSHT2xAddress);
     Wire.write(command);
-    delay(100);
     Wire.endTransmission();
+    delay(100);
 
     Wire.requestFrom(eSHT2xAddress, 3);
     uint32_t timeout = millis() + 300;       // Don't hang here for more than 300ms


### PR DESCRIPTION
Move the 100ms delay between the write and the read. Wouldn't work on my
nodemcu without this change. HTU21 is on a breakout board with 5v support
and 4k resistors.

Similar fix as was used here:
  http://www.esp8266.com/viewtopic.php?p=47122#p47122

This may also pertain to the issue:
  https://github.com/pasko-zh/brzo_i2c/tree/master/examples/HTU21D

Tested to on Amica nodemc V2 and on knock-off Arduino UNO.